### PR TITLE
Use Intl.Segmenter

### DIFF
--- a/denops/translate/constract.ts
+++ b/denops/translate/constract.ts
@@ -1,0 +1,43 @@
+import { Denops, fn } from "./deps.ts";
+async function slicing(
+  denops: Denops,
+  text: string,
+  maxWidth: number,
+  numerator = 1,
+  denominator = 2,
+): Promise<number> {
+  const mid = Math.floor(text.length * numerator / denominator);
+  if (await fn.strwidth(denops, text.slice(0, mid)) < maxWidth) {
+    if (await fn.strwidth(denops, text.slice(0, mid + 1)) >= maxWidth) {
+      return mid;
+    } else {
+      return slicing(
+        denops,
+        text,
+        maxWidth,
+        numerator * 2 + 1,
+        denominator * 2,
+      );
+    }
+  } else {
+    return slicing(denops, text, maxWidth, numerator * 2 - 1, denominator * 2);
+  }
+}
+export async function constract(
+  denops: Denops,
+  text: string,
+  maxWidth: number,
+): Promise<string[]> {
+  const results: string[] = [];
+  while (text != "") {
+    if (await fn.strwidth(denops, text) < maxWidth) {
+      results.push(text);
+      break;
+    } else {
+      const end = await slicing(denops, text, maxWidth);
+      results.push(text.slice(0, end));
+      text = text.slice(end);
+    }
+  }
+  return results;
+}

--- a/denops/translate/deps.ts
+++ b/denops/translate/deps.ts
@@ -1,5 +1,6 @@
 export type { Denops } from "https://deno.land/x/denops_std@v3.0.0/mod.ts";
 export { execute } from "https://deno.land/x/denops_std@v3.0.0/helper/mod.ts";
+export * as fn from "https://deno.land/x/denops_std@v3.0.0/function/mod.ts";
 export * as vars from "https://deno.land/x/denops_std@v3.0.0/variable/mod.ts";
 export * as autocmd from "https://deno.land/x/denops_std@v3.0.0/autocmd/mod.ts";
 export {
@@ -8,5 +9,4 @@ export {
   ensureString,
   isString,
 } from "https://deno.land/x/unknownutil@v1.1.4/mod.ts";
-export { openPopup } from "https://pax.deno.dev/Omochice/dps-popup-toy/mod.ts"
-
+export { openPopup } from "https://pax.deno.dev/Omochice/dps-popup-toy/mod.ts";

--- a/denops/translate/translate.ts
+++ b/denops/translate/translate.ts
@@ -1,37 +1,41 @@
-const endpoint =
-  "https://script.google.com/macros/s/AKfycbzdOBxUB9-PeT86IhOJO7oTbjEjJAf8ECUfrqW06eKLQTy8xdaLtUBmexx94Jl3cLNb/exec";
-
-interface translateResult {
+interface TranslateResult {
   code: number;
   text: string;
 }
 
 export async function translate(
-  rowStr: string | string[],
+  text: string[],
   sourceLanguage: string,
   targetLanguage: string,
-): Promise<translateResult> {
-  const text = typeof rowStr === "string" ? rowStr : rowStr.join("\n");
-
-  const url = endpoint + "?" + new URLSearchParams({
-    text: text,
+): Promise<TranslateResult> {
+  const endpoint =
+    "https://script.google.com/macros/s/AKfycbzdOBxUB9-PeT86IhOJO7oTbjEjJAf8ECUfrqW06eKLQTy8xdaLtUBmexx94Jl3cLNb/exec";
+  const body = new URLSearchParams({
+    text: text.join("\n"),
     source: sourceLanguage,
     target: targetLanguage,
   });
 
-  const res = await fetch(url);
+  const res = await fetch(endpoint + "?" + body, {
+    method: "GET",
+  }); // `fetch` with GET method cannot handle `body` parameter
+
   if (res.status != 200) {
     throw new Error(`Invalid status [${res.status}]`);
   } else {
     try {
-      const json = await res.json();
+      const json: TranslateResult = await res.json();
       if (json.code != 200) {
         throw new Error(`Invalid status [${json.code}]`);
       }
-      return json
+      return json;
     } catch (e) {
       // json decode error or not 200
       throw e;
     }
   }
+}
+
+export function extractTranslatedText(response: TranslateResult): string {
+  return response.text;
 }

--- a/doc/dps-translate-vim.txt
+++ b/doc/dps-translate-vim.txt
@@ -18,7 +18,7 @@ INSTALL					*dps-translate-vim-install*
 This plugin depends on below.
 
 * Vim >= 8.1.2424 or Neovim >= 0.4.4
-* Deno >= 1.11.0
+* Deno >= 1.8
 * vim-denops/denops.vim
 (<https://github.com/vim-denops/denops.vim>)
 
@@ -50,8 +50,7 @@ Also, you can give a sentence as an argument.
 If you want to translate multiple lines like this help text as one
 sentence, use `TranslateJoin`.
 >
-	If you want to translate multiple lines like this help text as one
-	sentence, use `TranslateJoin`.
+	:'<,'>TranslateJoin
 <
 Select some lines on visual mode and execute `TranslateJoin`.
 
@@ -68,11 +67,11 @@ VARIABLES				*dps-translate-vim-variables*
 
 `g:dps_translate_source`		*g:dps_translate_source*
 	The string of translation source language.
-	Default: None
+	Default: 'en'
 
 `g:dps_translate_target`		*g:dps_translate_target*
 	The string of translation source language.
-	Default: None
+	Default: 'ja'
 
 
 vim:tw=78:fo=tcq2mM:ts=4:ft=help:norl:noet:fdm=marker:fen:

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -39,7 +39,7 @@ Deno.test({
   fn: () => {
     self.fetch = MOCK_404;
     assertRejects(
-      () => translate("test string", "EN", "JA"),
+      () => translate(["test string"], "EN", "JA"),
     );
   },
 });
@@ -49,7 +49,7 @@ Deno.test({
     "If returned status code is 200, the function should return valid result.",
   fn: async () => {
     self.fetch = MOCK_200;
-    const actual = await translate("test string", "EN", "JA");
+    const actual = await translate(["test string"], "EN", "JA");
     assert("code" in actual, "result should have 'code' property");
     assert("text" in actual, "result should have 'text' property");
     assertEquals(actual.code, 200, "result.code should be 200");
@@ -61,7 +61,7 @@ Deno.test({
   fn: () => {
     self.fetch = MOCK_INVALID_JSON;
     assertRejects(
-      () => translate("test string", "EN", "JA"),
+      () => translate(["test string"], "EN", "JA"),
     );
   },
 });


### PR DESCRIPTION
This PR provides a implementation that use `Intl.Segmenter`.
It make be able to split translated text confortable.
But, This function can be used in only `deno  >= 1.8`. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter)
