### PR TITLE
Replace to VimScript

### DIFF
--- a/plugin/dps-translate.vim
+++ b/plugin/dps-translate.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_dps_translate_vim') && g:loaded_dps_translate_vim
+if get('g', 'loaded_dps_translate_vim', v:false)
   finish
 endif
 


### PR DESCRIPTION
This PR provides implementation using VimScript.

Denops is useful but it is little unefficiency when call vim api a lot.
So, this PR replace its to pure VimScript.

Functions that needs denops are below:

- Call web api
- `Intl.segmenter`
